### PR TITLE
Update repo links and add generic wallet methods

### DIFF
--- a/.changeset/clever-pants-remain.md
+++ b/.changeset/clever-pants-remain.md
@@ -1,0 +1,5 @@
+---
+"@elytro/sdk": minor
+---
+
+Added calcWalletAddressGeneric and createUnsignedDeployWalletUserOpGeneric methods to ElytroWallet and IElytroWallet for chain-agnostic wallet address calculation and deployment. Updated WalletFactory to support chainId as optional for salt calculation and wallet address generation. Deprecated older methods in favor of new generic versions.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
    <b>
         Elytro Lib
     </b>
-  <img alt="CI" src="https://github.com/SoulWallet/elytro-wallet-lib/actions/workflows/UnitTest.yml/badge.svg?branch=develop"/>
+  <img alt="CI" src="https://github.com/Elytro-eth/elytro-wallet-lib/actions/workflows/UnitTest.yml/badge.svg?branch=develop"/>
 </h1>
 
 <p align="center">
@@ -10,7 +10,7 @@ Library of the Elytro contract
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/"><b>Code</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/"><b>Code</b></a>
 </p>
 
 ## Table of Contents

--- a/packages/abi/README.md
+++ b/packages/abi/README.md
@@ -5,12 +5,12 @@
 </h1>
 
 <p align="center">
-soulwallet-contract ABI
+elytro-wallet-contract ABI
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/abi"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/abi/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/abi"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/abi/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 

--- a/packages/abi/docs/README.md
+++ b/packages/abi/docs/README.md
@@ -7,12 +7,12 @@
 </h1>
 
 <p align="center">
-soulwallet-contract ABI
+elytro-wallet-contract ABI
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/abi"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/abi/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/abi"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/abi/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 ## Table of Contents

--- a/packages/abi/package.json
+++ b/packages/abi/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "Elytro-contract ABI",
   "author": "Jayden@elytro",
-  "homepage": "https://github.com/SoulWallet/elytro-wallet-lib#readme",
+  "homepage": "https://github.com/Elytro-eth/elytro-wallet-lib#readme",
   "license": "GPL-3.0",
   "main": "./lib.cjs/main.js",
   "module": "./lib.esm/main.js",
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SoulWallet/elytro-wallet-lib.git"
+    "url": "git+https://github.com/Elytro-eth/elytro-wallet-lib.git"
   },
   "scripts": {
     "typedoc": "typedoc",
@@ -33,7 +33,7 @@
     "test": "jest"
   },
   "bugs": {
-    "url": "https://github.com/SoulWallet/elytro-wallet-lib/issues"
+    "url": "https://github.com/Elytro-eth/elytro-wallet-lib/issues"
   },
   "devDependencies": {
     "@types/node": "^20.10.7",

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -9,8 +9,8 @@ A database of token
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/assets"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/assets/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/assets"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/assets/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 

--- a/packages/assets/docs/README.md
+++ b/packages/assets/docs/README.md
@@ -11,8 +11,8 @@ A database of token
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/assets"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/assets/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/assets"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/assets/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 ## Table of Contents

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.1",
     "description": "A database of token",
     "author": "Jayden@elytro",
-    "homepage": "https://github.com/SoulWallet/elytro-wallet-lib#readme",
+    "homepage": "https://github.com/Elytro-eth/elytro-wallet-lib#readme",
     "license": "GPL-3.0",
     "main": "./lib.cjs/main.js",
     "module": "./lib.esm/main.js",
@@ -21,7 +21,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/SoulWallet/elytro-wallet-lib.git"
+        "url": "git+https://github.com/Elytro-eth/elytro-wallet-lib.git"
     },
     "scripts": {
         "typedoc": "typedoc",
@@ -33,7 +33,7 @@
         "test": "jest"
     },
     "bugs": {
-        "url": "https://github.com/SoulWallet/elytro-wallet-lib/issues"
+        "url": "https://github.com/Elytro-eth/elytro-wallet-lib/issues"
     },
     "dependencies": {
         "@elytro/result": "workspace:*"

--- a/packages/decoder/README.md
+++ b/packages/decoder/README.md
@@ -9,8 +9,8 @@ A lib for decode userOp.calldata. If it contains known token information, it wil
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/decoder"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/decoder/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/decoder"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/decoder/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 

--- a/packages/decoder/docs/README.md
+++ b/packages/decoder/docs/README.md
@@ -11,8 +11,8 @@ A lib for decode userOp.calldata. If it contains known token information, it wil
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/decoder"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/decoder/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/decoder"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/decoder/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 ## Table of Contents

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.1",
     "description": "A lib for decode userOp.calldata",
     "author": "Jayden@elytro",
-    "homepage": "https://github.com/SoulWallet/elytro-wallet-lib#readme",
+    "homepage": "https://github.com/Elytro-eth/elytro-wallet-lib#readme",
     "license": "GPL-3.0",
     "main": "./lib.cjs/main.js",
     "module": "./lib.esm/main.js",
@@ -21,7 +21,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/SoulWallet/elytro-wallet-lib.git"
+        "url": "git+https://github.com/Elytro-eth/elytro-wallet-lib.git"
     },
     "scripts": {
         "typedoc": "typedoc",
@@ -33,7 +33,7 @@
         "test": "jest"
     },
     "bugs": {
-        "url": "https://github.com/SoulWallet/elytro-wallet-lib/issues"
+        "url": "https://github.com/Elytro-eth/elytro-wallet-lib/issues"
     },
     "dependencies": {
         "@elytro/abi": "workspace:*",

--- a/packages/keyvault/README.md
+++ b/packages/keyvault/README.md
@@ -9,8 +9,8 @@ A lightweight private key management library that uses CryptoKey in the browser 
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/keyvault"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/keyvault/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/keyvault"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/keyvault/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 

--- a/packages/keyvault/docs/README.md
+++ b/packages/keyvault/docs/README.md
@@ -11,8 +11,8 @@ A lightweight private key management library that uses CryptoKey in the browser 
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/keyvault"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/keyvault/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/keyvault"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/keyvault/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 ## Table of Contents

--- a/packages/keyvault/package.json
+++ b/packages/keyvault/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.1",
     "description": "A lightweight private key management library",
     "author": "Jayden@elytro",
-    "homepage": "https://github.com/SoulWallet/elytro-wallet-lib#readme",
+    "homepage": "https://github.com/Elytro-eth/elytro-wallet-lib#readme",
     "license": "MIT",
     "main": "./lib.cjs/main.js",
     "module": "./lib.esm/main.js",
@@ -25,7 +25,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/SoulWallet/elytro-wallet-lib.git"
+        "url": "git+https://github.com/Elytro-eth/elytro-wallet-lib.git"
     },
     "scripts": {
         "typedoc": "typedoc",
@@ -36,7 +36,7 @@
         "test": "jest"
     },
     "bugs": {
-        "url": "https://github.com/SoulWallet/elytro-wallet-lib/issues"
+        "url": "https://github.com/Elytro-eth/elytro-wallet-lib/issues"
     },
     "dependencies": {
         "@elytro/result": "workspace:*",

--- a/packages/result/README.md
+++ b/packages/result/README.md
@@ -7,8 +7,8 @@
 <p align="center">A lib designed based on the philosophy of "Errors are values" (similar to Rust).</p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/result"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/result/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/result"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/result/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 

--- a/packages/result/docs/README.md
+++ b/packages/result/docs/README.md
@@ -9,8 +9,8 @@
 <p align="center">A lib designed based on the philosophy of "Errors are values" (similar to Rust).</p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/result"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/result/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/result"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/result/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 ## Table of Contents

--- a/packages/result/package.json
+++ b/packages/result/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "A lib designed based on the philosophy of 'Errors are values'",
   "author": "Jayden@elytro",
-  "homepage": "https://github.com/SoulWallet/elytro-wallet-lib#readme",
+  "homepage": "https://github.com/Elytro-eth/elytro-wallet-lib#readme",
   "license": "MIT",
   "main": "./lib.cjs/main.js",
   "module": "./lib.esm/main.js",
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SoulWallet/elytro-wallet-lib.git"
+    "url": "git+https://github.com/Elytro-eth/elytro-wallet-lib.git"
   },
   "scripts": {
     "typedoc": "typedoc",
@@ -32,7 +32,7 @@
     "test": "jest"
   },
   "bugs": {
-    "url": "https://github.com/SoulWallet/elytro-wallet-lib/issues"
+    "url": "https://github.com/Elytro-eth/elytro-wallet-lib/issues"
   },
   "dependencies": {},
   "devDependencies": {},

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -9,8 +9,8 @@ ElytroSDK = {  Basic Functions,  Bundler, KeyStore,  SignatureTools }
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/sdk"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/sdk/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/sdk"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/sdk/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 
@@ -58,7 +58,7 @@ import { Elytro, Transaction, Bundler } from "@elytro/sdk";
 / #TODO
 ```
 - Elytro SDK usage instructions are still being compiled. In the meantime, you can refer to the examples below:
-[deploy.ts](https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/internal-test/src/deploy.ts)
+[deploy.ts](https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/internal-test/src/deploy.ts)
 
 ## License
 

--- a/packages/sdk/docs/README.md
+++ b/packages/sdk/docs/README.md
@@ -11,8 +11,8 @@ ElytroSDK = {  Basic Functions,  Bundler, KeyStore,  SignatureTools }
 </p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/sdk"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/sdk/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/sdk"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/sdk/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 ## Table of Contents
@@ -55,7 +55,7 @@ import { Elytro, Transaction, Bundler } from "@elytro/sdk";
 / #TODO
 ```
 - Elytro SDK usage instructions are still being compiled. In the meantime, you can refer to the examples below:
-[deploy.ts](https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/internal-test/src/deploy.ts)
+[deploy.ts](https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/internal-test/src/deploy.ts)
 
 ## License
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.1",
     "description": "ElytroWalletSDK = {  Basic Functions,  Bundler, KeyStore,  SignatureTools }",
     "author": "Jayden@elytro",
-    "homepage": "https://github.com/SoulWallet/elytro-wallet-lib#readme",
+    "homepage": "https://github.com/Elytro-eth/elytro-wallet-lib#readme",
     "license": "GPL-3.0",
     "main": "./lib.cjs/main.js",
     "module": "./lib.esm/main.js",
@@ -24,7 +24,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/SoulWallet/elytro-wallet-lib.git"
+        "url": "git+https://github.com/Elytro-eth/elytro-wallet-lib.git"
     },
     "scripts": {
         "typedoc": "typedoc",
@@ -35,7 +35,7 @@
         "test": "jest"
     },
     "bugs": {
-        "url": "https://github.com/SoulWallet/elytro-wallet-lib/issues"
+        "url": "https://github.com/Elytro-eth/elytro-wallet-lib/issues"
     },
     "dependencies": {
         "@elytro/abi": "workspace:*",

--- a/packages/sdk/src/elytroWallet.ts
+++ b/packages/sdk/src/elytroWallet.ts
@@ -259,16 +259,51 @@ export class ElytroWallet implements IElytroWallet {
     }
 
     /**
-     * get wallet address by index
-     *
-     * @param {number} index readable index
-     * @param {InitialKey[]} initialKeys initial keys
-     * @param {string} initialGuardianHash initial guardian hash
-     * @param {number} [initialGuardianSafePeriod] initial guardian safe period
-     * @param {(number | string)} [chainId] number or hex string(must start with 0x)
+     * calcuate the wallet address from the index, initialKey and initialGuardianHash, the address will be the same on different chain.
+     * @abstract
+     * @param {number} index
+     * @param {InitialKey[]} initialKeys
+     * @param {string} initialGuardianHash
+     * @param {number} [initialGuardianSafePeriod]
      * @return {*}  {Promise<Result<string, Error>>}
-     * @memberof ElytroWallet
+     * @memberof IElytroWallet
      */
+    async calcWalletAddressGeneric(
+        index: number,
+        initialKeys: InitialKey[],
+        initialGuardianHash: string,
+        initialGuardianSafePeriod?: number
+    ): Promise<Result<string, Error>> {
+        const _initializeDataRet = await this.initializeData(initialKeys, initialGuardianHash, initialGuardianSafePeriod);
+        if (_initializeDataRet.isErr() === true) {
+            return new Err(_initializeDataRet.ERR);
+        }
+        const _onChainConfig = await this.getOnChainConfig();
+        if (_onChainConfig.isErr() === true) {
+            throw new Err(_onChainConfig.ERR);
+        }
+        return new Ok(WalletFactory.getWalletAddressByIndex(
+            this.elytroWalletFactoryAddress,
+            _onChainConfig.OK.elytroWalletLogic,
+            _initializeDataRet.OK,
+            index,
+            undefined
+        ));
+    }
+
+
+    /**
+    * calcuate the wallet address from the index, initialKey and initialGuardianHash.
+    * @deprecated use calcWalletAddressGeneric instead
+    * @abstract
+    * @param {number} index
+    * @param {InitialKey[]} initialKeys
+    * @param {string} initialGuardianHash
+    * @param {number} [initialGuardianSafePeriod]
+    * @param {number|string} [chainId] number or hex string(must start with 0x)
+    * @return {*}  {Promise<Result<string, Error>>}
+    * @memberof IElytroWallet
+    */
     async calcWalletAddress(
         index: number,
         initialKeys: InitialKey[],
@@ -349,6 +384,16 @@ export class ElytroWallet implements IElytroWallet {
         }
     }
 
+    /**
+     * create unsigned deploy wallet UserOp.
+     * @deprecated use createUnsignedDeployWalletUserOpGeneric instead
+     * @param {number} index
+     * @param {InitialKey[]} initialKeys
+     * @param {string} initialGuardianHash
+     * @param {string} [callData]
+     * @param {number} [initialGuardianSafePeriod]
+     * @return {*}  {Promise<Result<UserOperation, Error>>}
+     */
     async createUnsignedDeployWalletUserOp(
         index: number,
         initialKeys: InitialKey[],
@@ -379,6 +424,67 @@ export class ElytroWallet implements IElytroWallet {
             .substring(2)
             }`.toLowerCase();
         const senderRet = await this.calcWalletAddress(index, initialKeys, initialGuardianHash, initialGuardianSafePeriod);
+        if (senderRet.isErr() === true) {
+            return new Err(senderRet.ERR);
+        }
+        const _userOperation: UserOperation = {
+            sender: senderRet.OK,
+            nonce: 0,
+            factory,
+            factoryData,
+            callData,
+            callGasLimit: 0,
+            verificationGasLimit: 0,
+            preVerificationGas: this.preVerificationGasDeploy,
+            maxFeePerGas: 2,
+            maxPriorityFeePerGas: 1,
+            paymaster: null,
+            paymasterVerificationGasLimit: null,
+            paymasterPostOpGasLimit: null,
+            paymasterData: null,
+            signature: "0x"
+        };
+
+        return new Ok(_userOperation);
+    }
+
+
+    /**
+     * create unsigned deploy wallet UserOp.
+     * @param {number} index
+     * @param {InitialKey[]} initialKeys
+     * @param {string} initialGuardianHash
+     * @param {string} [callData]
+     * @param {number} [initialGuardianSafePeriod]
+     * @return {*}  {Promise<Result<UserOperation, Error>>}
+     */
+    async createUnsignedDeployWalletUserOpGeneric(
+        index: number,
+        initialKeys: InitialKey[],
+        initialGuardianHash: string,
+        callData: string = "0x",
+        initialGuardianSafePeriod?: number
+    ): Promise<Result<UserOperation, Error>> {
+        const ret = TypeGuard.onlyBytes(callData);
+        if (ret.isErr() === true) {
+            return new Err(
+                new Error(ret.ERR)
+            );
+        }
+        const _initializeData = await this.initializeData(initialKeys, initialGuardianHash, initialGuardianSafePeriod);
+        if (_initializeData.isErr() === true) {
+            return new Err(_initializeData.ERR);
+        }
+
+        const factory = this.elytroWalletFactoryAddress;
+        const factoryData = `${new ethers.Interface(ABI_ElytroFactory)
+            .encodeFunctionData("createWallet", [_initializeData.OK,
+            WalletFactory.calcWalletAddressSalt(index, undefined)
+            ])
+            .substring(2)
+            }`.toLowerCase();
+
+        const senderRet = await this.calcWalletAddressGeneric(index, initialKeys, initialGuardianHash, initialGuardianSafePeriod);
         if (senderRet.isErr() === true) {
             return new Err(senderRet.ERR);
         }

--- a/packages/sdk/src/interface/IElytroWallet.ts
+++ b/packages/sdk/src/interface/IElytroWallet.ts
@@ -38,7 +38,26 @@ export abstract class IElytroWallet {
 
     /**
      * calcuate the wallet address from the index, initialKey and initialGuardianHash.
-     *
+     * @deprecated use calcWalletAddressGeneric instead
+     * @abstract
+     * @param {number} index
+     * @param {InitialKey[]} initialKeys
+     * @param {string} initialGuardianHash
+     * @param {number} [initialGuardianSafePeriod]
+     * @param {number|string} [chainId] number or hex string(must start with 0x)
+     * @return {*}  {Promise<Result<string, Error>>}
+     * @memberof IElytroWallet
+     */
+    abstract calcWalletAddress(
+        index: number,
+        initialKeys: InitialKey[],
+        initialGuardianHash: string,
+        initialGuardianSafePeriod?: number,
+        chainId?: number | string
+    ): Promise<Result<string, Error>>;
+
+    /**
+     * calcuate the wallet address from the index, initialKey and initialGuardianHash, the address will be the same on different chain.
      * @abstract
      * @param {number} index
      * @param {InitialKey[]} initialKeys
@@ -47,7 +66,7 @@ export abstract class IElytroWallet {
      * @return {*}  {Promise<Result<string, Error>>}
      * @memberof IElytroWallet
      */
-    abstract calcWalletAddress(
+    abstract calcWalletAddressGeneric(
         index: number,
         initialKeys: InitialKey[],
         initialGuardianHash: string,
@@ -57,7 +76,7 @@ export abstract class IElytroWallet {
 
     /**
      * create unsigned deploy wallet UserOp.
-     *
+     * @deprecated use createUnsignedDeployWalletUserOpGeneric instead
      * @abstract
      * @param {number} index
      * @param {InitialKey[]} initialKeys
@@ -68,6 +87,25 @@ export abstract class IElytroWallet {
      * @memberof IElytroWallet
      */
     abstract createUnsignedDeployWalletUserOp(
+        index: number,
+        initialKeys: InitialKey[],
+        initialGuardianHash: string,
+        callData?: string,
+        initialGuardianSafePeriod?: number
+    ): Promise<Result<UserOperation, Error>>;
+
+    /**
+     * create unsigned deploy wallet UserOp.
+     * @abstract
+     * @param {number} index
+     * @param {InitialKey[]} initialKeys
+     * @param {string} initialGuardianHash
+     * @param {string} [callData]
+     * @param {number} [initialGuardianSafePeriod]
+     * @return {*}  {Promise<Result<UserOperation, Error>>}
+     * @memberof IElytroWallet
+     */
+    abstract createUnsignedDeployWalletUserOpGeneric(
         index: number,
         initialKeys: InitialKey[],
         initialGuardianHash: string,

--- a/packages/sdk/src/tools/walletFactory.ts
+++ b/packages/sdk/src/tools/walletFactory.ts
@@ -38,25 +38,28 @@ export class WalletFactory {
      * 
      * @static
      * @param {number} index readable index
-     * @param {(number|string)} chainId number or hex string(must start with 0x)
+     * @param {(number|string|undefined)} chainId number or hex string(must start with 0x), if undefined, baseSalt = 0
      * @return {*}  {string} bytes32 salt
      * @memberof WalletFactory
      */
-    static calcWalletAddressSalt(index: number, chainId: number | string): string {
-        let _chainId = '';
-        if (typeof chainId === 'number') {
-            _chainId = chainId.toString(16).toLowerCase();
-        } else {
-            if (!chainId.startsWith('0x')) {
-                throw new Error('chainId must start with 0x');
+    static calcWalletAddressSalt(index: number, chainId: number | string | undefined): string {
+        let baseSalt = BigInt(0);
+        if (chainId !== undefined) {
+            let _chainId = '';
+            if (typeof chainId === 'number') {
+                _chainId = chainId.toString(16).toLowerCase();
+            } else {
+                if (!chainId.startsWith('0x')) {
+                    throw new Error('chainId must start with 0x');
+                }
+                _chainId = chainId.substring(2).toLowerCase();
             }
-            _chainId = chainId.substring(2).toLowerCase();
+            if (_chainId.length % 2 === 1) {
+                _chainId = '0' + _chainId;
+            }
+            _chainId = '0x' + _chainId;
+            baseSalt = BigInt(ethers.keccak256(_chainId));
         }
-        if (_chainId.length % 2 === 1) {
-            _chainId = '0' + _chainId;
-        }
-        _chainId = '0x' + _chainId;
-        let baseSalt = BigInt(ethers.keccak256(_chainId));
         baseSalt += BigInt(index);
         return Hex.paddingZero(baseSalt, 32).toLowerCase();
     }
@@ -92,11 +95,11 @@ export class WalletFactory {
      * @param {string} implementation
      * @param {string} initializer
      * @param {number} index
-     * @param {(number | string)} chainId number or hex string(must start with 0x)
+     * @param {(number | string | undefined)} chainId number or hex string(must start with 0x), if undefined the wallet address will be same on all chains
      * @return {*}  {string}
      * @memberof WalletFactory
      */
-    static getWalletAddressByIndex(elytroWalletFactoryAddress: string, implementation: string, initializer: string, index: number, chainId: number | string): string {
+    static getWalletAddressByIndex(elytroWalletFactoryAddress: string, implementation: string, initializer: string, index: number, chainId: number | string | undefined): string {
         return WalletFactory.getWalletAddress(
             elytroWalletFactoryAddress,
             implementation,

--- a/packages/zkemailproof/README.md
+++ b/packages/zkemailproof/README.md
@@ -7,8 +7,8 @@
 <p align="center"></p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/zkemail"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/zkemail/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/zkemail"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/zkemail/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 

--- a/packages/zkemailproof/docs/README.md
+++ b/packages/zkemailproof/docs/README.md
@@ -9,8 +9,8 @@
 <p align="center"></p>
 
 <p align="center">
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/tree/develop/packages/zkemail"><b>Code</b></a> •
-    <a href="https://github.com/SoulWallet/elytro-wallet-lib/blob/develop/packages/zkemail/docs/modules.md"><b>Documentation</b></a>
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/tree/develop/packages/zkemail"><b>Code</b></a> •
+    <a href="https://github.com/Elytro-eth/elytro-wallet-lib/blob/develop/packages/zkemail/docs/modules.md"><b>Documentation</b></a>
 </p>
 
 ## Table of Contents

--- a/packages/zkemailproof/package.json
+++ b/packages/zkemailproof/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "A lib designed based on the philosophy of 'Errors are values'",
   "author": "Jayden@elytro",
-  "homepage": "https://github.com/SoulWallet/elytro-wallet-lib#readme",
+  "homepage": "https://github.com/Elytro-eth/elytro-wallet-lib#readme",
   "license": "MIT",
   "main": "./lib.cjs/main.js",
   "module": "./lib.esm/main.js",
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SoulWallet/elytro-wallet-lib.git"
+    "url": "git+https://github.com/Elytro-eth/elytro-wallet-lib.git"
   },
   "scripts": {
     "typedoc": "typedoc",
@@ -32,7 +32,7 @@
     "test": "jest"
   },
   "bugs": {
-    "url": "https://github.com/SoulWallet/elytro-wallet-lib/issues"
+    "url": "https://github.com/Elytro-eth/elytro-wallet-lib/issues"
   },
   "dependencies": {
     "@elytro/abi": "workspace:*",


### PR DESCRIPTION
Changed all references from SoulWallet to Elytro-eth in documentation and package.json files. Added calcWalletAddressGeneric and createUnsignedDeployWalletUserOpGeneric methods to ElytroWallet and IElytroWallet for chain-agnostic wallet address calculation and deployment. Updated WalletFactory to support chainId as optional for salt calculation and wallet address generation. Deprecated older methods in favor of new generic versions.