### PR TITLE
Remove manual gas adjustment for hook signature estimation

### DIFF
--- a/.changeset/friendly-birds-fetch.md
+++ b/.changeset/friendly-birds-fetch.md
@@ -1,0 +1,5 @@
+---
+"@elytro/sdk": patch
+---
+
+Eliminated the logic that manually increased verificationGasLimit when using semi-valid hook input data in ElytroWallet. The estimation now relies solely on the result from eth_estimateUserOperationGas, which supports stateOverride for more accurate simulation.

--- a/packages/sdk/src/bundler.ts
+++ b/packages/sdk/src/bundler.ts
@@ -43,6 +43,22 @@ export class Bundler implements IBundler {
         }
     }
 
+    /**
+     * 
+     * @param entryPoint 
+     * @param userOp 
+     * @param stateOverride The `stateOverride` field is used to modify the blockchain state during gas estimation.
+     * 1. When the wallet has no ETH balance, gas estimation will fail due to insufficient funds.
+     *    In such cases, you can use `stateOverride` to temporarily set the account balance to 1 ETH
+     *    during the simulation to ensure a successful estimation.
+     *
+     * 2. When the wallet uses a hook, the simulation may fail to execute `validateUserOp`
+     *    because the hook signature is invalid during estimation. As a result, the simulated
+     *    `verificationGasLimit` will be lower than the actual required value. To address this,
+     *    you can use `stateOverride` to replace the hook contract bytecode with a non-reverting
+     *    mock version that consumes a similar amount of gas before calling `estimateUserOperationGas`.
+     * @returns 
+     */
     async eth_estimateUserOperationGas(entryPoint: string, userOp: UserOperation, stateOverride?: Record<string, StateOverride>): Promise<Result<UserOpGas, UserOpErrors>> {
         try {
             const params = [
@@ -61,7 +77,6 @@ export class Bundler implements IBundler {
             } else {
                 return new Ok(userOpGas);
             }
-
         } catch (error: unknown) {
             if (error instanceof Error) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/sdk/src/elytroWallet.ts
+++ b/packages/sdk/src/elytroWallet.ts
@@ -725,36 +725,7 @@ export class ElytroWallet implements IElytroWallet {
             if (userOpGasRet.isErr() === true) {
                 return new Err(userOpGasRet.ERR);
             }
-
-            /**
-             * Note: If an invalid Hook signature is used, the `validateUserOp` function will not be executed 
-             * during `estimateUserOperationGas`, resulting in a lower `verificationGasLimit` than the actual value.
-             * When using ECDSA signatures, the estimated value will be about 3000gas lower than the real cost.
-             * For other types of keys, the difference may be even larger depending on the complexity of the signature verification.
-             */
-            const gasRet = userOpGasRet.OK;
-            if (semiValidHookInputData !== undefined && semiValidHookInputData.length > 0) {
-                let _gas = 0;
-                switch (signkeyType) {
-                    case undefined:
-                    case SignkeyType.EOA:
-                        _gas = 2000 + 3000;
-                        break;
-                    case SignkeyType.P256:
-                        // EIP-7951
-                        _gas = 2000 + 10200;
-                        // No address(0x100)
-                        // _gas = 2000 + 300000;
-                        break;
-                    case SignkeyType.RS256:
-                        _gas = 2000 + 11000;
-                        break
-                    default:
-                        throw new Error("invalid signkeyType");
-                }
-                gasRet.verificationGasLimit = `0x${(BigInt(gasRet.verificationGasLimit) + BigInt(_gas)).toString(16)}`;
-            }
-            return new Ok(gasRet);
+            return new Ok(userOpGasRet.OK);
         }
         catch (error: unknown) {
             if (error instanceof Error) {


### PR DESCRIPTION
Eliminated the logic that manually increased verificationGasLimit when using semi-valid hook input data in ElytroWallet. The estimation now relies solely on the result from eth_estimateUserOperationGas, which supports stateOverride for more accurate simulation.